### PR TITLE
Ny gyldighetsdato for private vilkår

### DIFF
--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -284,4 +284,4 @@ Ved mislighold vil Digipost kunne sperre utvalgt funksjonalitet og tilgang for B
 
 Kontrakten er underlagt og skal tolkes i samsvar med norsk rett. Tvister mellom Posten og Brukeren skal søkes løst i minnelighet. Dersom det ikke lar seg gjøre, kan hver av partene bringe tvisten inn for de ordinære domstoler i samsvar med tvistelovens regler vedrørende verneting.
 
-Vilkårene trer i kraft den 8. desember 2015
+Vilkårene trer i kraft den 17. august 2016


### PR DESCRIPTION
Private vilkår har blitt endret (i dette repoet) etter gyldighetsdatoen som stod i dokumentet, og deployet (jfr. https://trello.com/c/9PdXqSMB/2353-apne-sider-oppdatere-avtale-og-vilkar-for-privat-og-bedrift) 16/8-2016.

Gyldighetsdatoen på nettsiden er nå 17/8-2016. Denne pullrequesten vil oppdatere de private vilkårene i dette repoet til det samme.
