### PR TITLE
Riktige gyldighetsdatoer. Samme format på privat og bedrift.

### DIFF
--- a/digipost-vilkaar-bedrift.md
+++ b/digipost-vilkaar-bedrift.md
@@ -290,4 +290,4 @@ Posten er å anse som databehandler for personopplysninger som Kunden er behandl
 Etter signering er gjennomført får Kunden det ferdig signerte dokumentet. Dette kan lastes ned eller arkiveres i Digipost. Personen(e) som har signert dokumentet får på tilsvarende måte tilgang til en kopi av det signerte dokumentet, som de kan laste ned eller arkivere i Digipost.
 
 
-Gyldighetsperiode: Fra 17. mars 2016
+Gyldig fra 17. august 2016

--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -284,4 +284,4 @@ Ved mislighold vil Digipost kunne sperre utvalgt funksjonalitet og tilgang for B
 
 Kontrakten er underlagt og skal tolkes i samsvar med norsk rett. Tvister mellom Posten og Brukeren skal søkes løst i minnelighet. Dersom det ikke lar seg gjøre, kan hver av partene bringe tvisten inn for de ordinære domstoler i samsvar med tvistelovens regler vedrørende verneting.
 
-Vilkårene trer i kraft den 17. august 2016
+Gyldig fra 17. august 2016


### PR DESCRIPTION
Oppdatert med riktige gyldighetsdatoer for privat og bedrift. Bruker samme format og formulering for datoene i privat og bedrift. Ref.: https://trello.com/c/QJxOUeuV/893-apne-sider-oppdatere-vilkarsdato-pa-apne-sider-og-github
