### PR TITLE
Endre til at konto slettes 12 mnd etter død pluss andre fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Posten Norge AS leverer tjenestene Digipost og Posten signering. Tilknyttet disse tjenestene finnes følgende avtalevilkår og personvernerklæringer:
 
-* Avtalevilkår for bruk av Digipost for privatpersoner
+* Avtalevilkår for bruk av Digipost for privatpersoner (norsk og engelsk)
 * Avtalevilkår for bruk av Digipost for bedrifter
-* Personvern i Digipost (personvernerklæring)
+* Personvern i Digipost (personvernerklæring, norsk og engelsk)
 * Personvern i Posten signering (personvernerklæring)
 
 Posten benytter GitHub for administrasjon av disse dokumentene. Eventuelle forslag til forbedringer, korrektur og liknende kan sendes som pull request.

--- a/digipost-personvernerklaering-engelsk.md
+++ b/digipost-personvernerklaering-engelsk.md
@@ -1,0 +1,127 @@
+# Privacy policy for Digipost
+
+Personal data is information that can be linked to you as a person. This may include your name, address, other contact details and information that can be linked to you indirectly as a person.
+
+As a user, Digipost wishes to provide you with useful information about how we store and use the personal data you have provided to us in connection with the use of our services. It is important to us to ensure that you feel confident at all times that we are keeping and using this information in a confidential, correct and legal manner.
+
+## 1. BRIEF PRESENTATION OF DIGIPOST AND RELATIONSHIP TO NORWAY POST AS THE DATA CONTROLLER
+
+Digipost is Norway Post’s digital mailbox. As a private individual, you can receive and store digital mail through this service. Thus Norway Post owns the Digipost service and Norway Post is the data controller for all personal data about you that we receive when you start using Digipost services.
+
+As a user of Digipost, you have access to your mailbox either via our website or via Digipost’s own app. This privacy policy applies both when using the website and when using the Digipost app.
+
+Norway Post is the data controller in accordance with Norwegian privacy legislation and is responsible for ensuring that the processing of personal data is carried out in a responsible and legal manner in accordance with the regulations.
+
+Norway Post has appointed a separate data protection officer whom you can contact if you have any questions about how your personal data is processed, and you can get help with exercising your rights under the Personal Data Act.
+
+You can contact Norway Post’s data protection officer at [personvernombud@posten.no](mailto:personvernombud@posten.no).
+
+## 2. DIGIPOST LOOKS AFTER YOUR DOCUMENTS AND PERSONAL DATA
+
+All the documents that you store in Digipost are encrypted and are your personal property. Digipost does not have access to your mailbox and cannot share the content with anyone else without your permission.
+
+As a digital mailbox, we ensure that as a user you can receive digital mail from senders with whom Digipost has an agreement. Digipost is therefore the data processor for the senders and ensures that the mail they send arrives safely to you as a user of our services. We send a delivery confirmation to the sender when the mail has been delivered to you as the recipient. From that point on, the mail is your property and only you will decide on the further processing of it.
+
+Norway Post is not responsible for the content of mail sent. If you have any questions or comments about the mail you receive, you must contact the sender of the mail you receive in your digital mailbox.
+
+## 3. FURTHER INFORMATION ABOUT DIGIPOST COLLECTION AND USE OF PERSONAL DATA
+
+Digipost processes personal data about you only in order to fulfil the agreement we have entered into with you. We will explain below what we use the data for, what data we process and how long we keep the data we collect.
+
+### 3.1 What does Digipost use the information for?
+
+- Identification and addressing of recipient and sender of digital mail and physical mail
+- To notify you that you have received mail in your mailbox
+- To manage your mailbox access
+- To let you read and process digital mail
+- Integration and implementation of banking services, if you have enabled this
+- To send you information about our services and updates, including new functionality and operational information as well as customer surveys. You can also receive marketing enquiries from the Norway Post Group, if you have consented to this.
+
+### 3.2 Legal basis for processing the data
+
+While you have an active account with us, we process data in order to fulfil the agreement we have entered into with you. We then have a legal basis for processing the data because this is necessary to fulfil the agreement, cf. Art. 6 b of the Personal Data Regulation).
+
+### 3.3 What data we process about you
+
+- Name
+- Contact details: Address, telephone number, email address, Digipost address
+- Personal alias: An identifier that we use to identify Digipost users so that senders can check whether it is possible to send digital mail to a specific person.
+- Personal identification number; for authentication and identification of you as a recipient and to ensure that you are the correct recipient of the mail you receive in your digital mailbox
+- Information about your use of the Digipost solution, including login and actions you perform in the solution
+- Address list created by you
+- Bank account number, credit card and other payment information in the event that this is necessary for the performance and follow-up of services of your choice
+- Electronic identification (IP address, cookies)
+
+Information beyond this is processed only if you have given your consent to this. You may withdraw your consent at any time. You can manage this yourself by going to “Your consents and apps” in the settings.
+
+Digipost uses Norway Post’s address register to receive updates from the national population register, thereby ensuring that Digipost’s information is updated at all times in relation to our legal basis. In order to ensure correct and updated information, your national personal identification number or D number will be registered in Norway Post’s address register when you register in Digipost, if this is not already registered here.
+
+### 3.4 How long the data is stored (deletion rules)
+
+The above information is stored for as long as you have an active account with Digipost.
+
+However, information about usage and login is deleted after 2 years.
+
+You can decide for yourself whether to keep or delete letters and other items you receive in your electronic mailbox. When you delete something from your digital mailbox, we delete it on our side. We have backups of our systems, which means that deleted documents will remain in these for up to 365 days after deletion.
+
+### 3.5 Processing of data after you have closed your account with Digipost
+
+We need to keep some information about you for a transitional period after you have terminated your agreement with Digipost. As a general rule, information about documents, accesses and other information about your mail and mailbox will be retained for 3 months after the agreement has been terminated.
+
+However, we must keep information about your name, personal identification number and notifications for three years in order to ensure history, troubleshooting and possible disputes. We need this to be able to prove that mail has been delivered to you, and to enable us to find any errors in the system if anything does not go as it should. Your Digipost address will not be deleted so as to ensure that duplicates are not issued.
+
+The legal basis for the storage of said information after the agreement has been terminated is the fact that Digipost has a legitimate interest in further storage, cf. Art. 6 f of the General Data Protection Regulation. Digipost has found that a number of our customers may want to undo the termination or that the deletion of the account was terminated incorrectly. Based on this, Digipost is of the opinion that storage of the information for 3 months after termination is justified and that storage in these cases safeguards the customer’s interests.
+
+If the account is terminated after a death, the information about the account and the deceased will be stored for 12 months after we receive notification of the death from the national population register. This is to ensure that information that is necessary for the deceased’s heirs is not lost and that all surviving relatives receive necessary and important information.
+
+## 4. SHARING OF PERSONAL DATA
+
+Digipost will not disclose information to third parties unless you, as a user of the service, consent to this. We may, with your consent, supply invoices to your bank, for example, or provide companies of your choice with the option to retrieve information. If so, this is something that you manage as a user, and any consents can be withdrawn at any time.
+
+Necessary personal data will be provided to perform this service if this is a prerequisite for sending, receiving or archiving messages and mail in your mailbox. This means, among other things, that for us to be able to deliver digital mail to you under the agreement, your Digipost address must be submitted to any sender so that they can register this and you as the recipient.
+
+Other disclosure of information will only take place if this is ordered and the recipient has legal authority for such a disclosure requirement.
+
+## 5. USE OF DATA PROCESSORS
+
+Digipost uses subcontractors in certain cases for the implementation of some of our services and the fulfilment of the agreement we have with our users; data processors in the sense of the Personal Data Act. If we use a data processing agreement, special agreements are entered into and the data processor may only use the data to carry out tasks on Digipost’s behalf. Digipost’s data processors are required to process data in accordance with this privacy policy.
+
+## 6. RIGHT OF ACCESS, CORRECTION AND ERASURE OF YOUR DATA
+
+You have a number of rights in accordance with the Personal Data Act when we process personal data about you.
+
+As a Digipost user, you always have the right to access the information we have registered about you. All contact information we have registered about you can be accessed via your Digipost account. You can see here which data we have registered and correct some of the data yourself if you discover that the data is incorrect or outdated. If you would like access to any other information we have registered, you can contact the data protection officer, see contact information below.
+
+Otherwise, you can easily log into your mailbox yourself to delete or download what you have received and saved.
+
+You can also request information about the deletion in connection with the termination of your account, unless Digipost has justified the need for further storage.
+
+For certain services in Digipost, you can choose whether you want to give us consent to use information about you so that we can deliver the service. You may withdraw your consent to us at any time. You can manage this yourself by going to “Your consents and apps” in the settings.
+
+To exercise your rights, you can contact our data protection officer – contact [personvernombud@posten.no](mailto:personvernombud@posten.no)
+
+You can also contact the Norwegian Data Protection Authority if you wish to complain about our processing of personal data, [www.datatilsynet.no](www.datatilsynet.no).
+
+Norwegian Data Protection Authority
+Postboks 458 Sentrum
+0105 Oslo
+
+## 7. INFORMATION SECURITY
+
+Norway Post aims to ensure that Digipost is the most secure digital mailbox in Norway and uses recognised standards and best practices in our efforts to secure your mailbox and exchange information.
+
+Digipost conducts regular risk assessments and security tests of the solutions and maintains good dialogue with the authorities and other security environments in order to comply with the best standards.
+
+Our most important security measures are:
+
+- Security level 4 authentication.
+- All information exchange takes place with strong encryption (SSL, SSH).
+- Sensitive information can be encrypted end-to-end with qualified certificates.
+- All actions performed by operational personnel are logged in separate event logs.
+- All documents are stored after encryption using strong encryption keys.
+- All senders and recipients are identified according to strict guidelines. This means that you can always be sure which sender a notification comes from.
+- Digipost’s servers are located in one of Norway’s most secure operating centres, run by a provider who has extensive experience of dealing with business-critical and sensitive information.
+- All your documents are backed up and all your documents are stored in two different locations at all times so that you are protected from fire, server destruction, etc.
+- Norway Post’s employees or employees of subcontractors do not have access to your documents. Only a few operators have access to Digipost’s systems, but all documents are stored encrypted and so they do not have access to your data either.
+
+Digipost updates and evaluates our security measures on an ongoing basis.

--- a/digipost-personvernerklaering.md
+++ b/digipost-personvernerklaering.md
@@ -30,7 +30,7 @@ Digipost behandler personopplysninger om deg kun for å oppfylle avtalen vi har 
 
 ### 3.1 Hva bruker Digipost opplysningene til?
 
--	Identifisering og adressering av mottaker og avsender av digital post
+-	Identifisering og adressering av mottaker og avsender av digital post og fysisk post
 -	Varsle deg om at du har mottatt post i din postkasse
 -	Administrere dine postkassetilganger
 -	La deg lese og behandle digital post
@@ -54,6 +54,8 @@ Mens du har en aktiv konto hos oss behandler vi opplysninger for å kunne gjenno
 
 Opplysninger ut over dette behandles kun dersom du har gitt samtykke til dette. Du kan til enhver tid trekke tilbake ditt samtykke. Dette kan du selv administrere ved å gå til "Dine samtykker og apper" i innstillingene. 
 
+Digipost bruker Postens adresseregister for å motta oppdateringer fra folkeregisteret og gjennom dette sikre at Digiposts opplysninger til enhver tid er oppdaterte i forhold til vårt behandlingsgrunnlag. For å sikre korrekte og oppdaterte opplysninger vil ditt fødsels- eller D-nummer registreres i Postens adresseregister når du registrerer deg i Digipost, dersom dette ikke er registrert her fra før.
+
 ### 3.4 Hvor lenge opplysningene oppbevares (sletteregler)
 
 Opplysningene som er nevnt over oppbevares så lenge du har en aktiv konto hos Digipost. 
@@ -70,7 +72,7 @@ Vi må imidlertid oppbevare opplysninger om navn, fødselsnummer og varsler i tr
 
 Hjemmel for oppbevaring av nevnte opplysninger etter at avtalen er sagt opp er begrunnet i at Digipost har berettiget interesse for videre oppbevaring jf personvernforordningen art 6 f.  Digipost har erfart at flere av våre kunder kan angre avslutningen eller at slettingen av kontoen var feilaktig avsluttet. Basert på dette mener Digipost at en oppbevaring av opplysningene i 3 måneder etter avslutning er berettiget og at lagring i disse tilfellene ivaretar de kundens interesser. 
 
-Dersom kontoen avsluttes etter et dødsfall oppbevares opplysningen om kontoen og avdøde i 9 måneder etter at vi mottar melding om dødsfall fra folkeregisteret. Dette for å sikre at opplysninger som er nødvendig for avdødes etterkommere ikke går tapt og at alle etterlatte får nødvendig og viktig informasjon. 
+Dersom kontoen avsluttes etter et dødsfall oppbevares opplysningen om kontoen og avdøde i 12 måneder etter at vi mottar melding om dødsfall fra folkeregisteret. Dette for å sikre at opplysninger som er nødvendig for avdødes etterkommere ikke går tapt og at alle etterlatte får nødvendig og viktig informasjon.
 
 ## 4. Deling av personopplysninger
 

--- a/digipost-vilkaar-privat-engelsk.md
+++ b/digipost-vilkaar-privat-engelsk.md
@@ -1,0 +1,483 @@
+# Agreement terms and conditions for use of Digipost for private individuals
+
+The terms below cover the rights and obligations that you have as a user of
+Digipost, and by accepting the terms you also give permission to process
+personal data about yourself. You must therefore review the terms and
+conditions carefully and assess whether you accept these before you start
+using Digipost. If you have any questions about the terms and conditions, we
+recommend that you contact Norway Post by email at
+[kundeservice@digipost.no](mailto:kundeservice@digipost.no), and
+await Norway Post’s response before accepting the terms and conditions and
+using Digipost.
+
+Below are the terms and conditions governing the use of Digipost (“Terms”), a
+service provided by Posten Norge AS (“Norway Post”), co. reg. no. 984 661 185.
+The Terms are regarded as read, understood and accepted by the natural person
+who will use Digipost (“the User”) by the User checking “I accept the Digipost
+terms”, clicking on the button marked “Register me for Digipost” and using
+Digipost. The User is advised to print out the Terms and keep them, together
+with acknowledgement of acceptance of the service.
+The User must be at least 15 years of age to be able to register and use
+Digipost.
+
+The Terms apply to the User’s use of Digipost for purely personal or other
+private purposes. The Customer Terms for Digipost – Company apply to public
+authorities, companies (including sole proprietorships), organisations and
+others who use Digipost for purposes other than purely personal or other
+private purposes.
+
+## **1** ABOUT DIGIPOST
+
+Digipost provides access to send, receive, sign and archive information and
+data (“Messages”) in electronic form from registered users of the service
+(such as public authorities, companies, organisations and private
+individuals). The following information will be collected during the
+registration process before the User can access Digipost:
+
+- Name
+- Personal identification number
+- Address
+- Email address
+- Mobile phone number
+
+Messages via Digipost are based on secure identification of senders,
+recipients and their physical postal addresses. It is therefore necessary for
+the User to provide the correct information in order to fulfil the contractual
+relationship under these Terms.
+
+Digipost also includes a number of optional additional services. These Terms
+also apply to the supplementary services unless stated otherwise in the
+contractual basis for the supplementary service in question.
+
+## **2** PRICE AND INVOICING TERMS
+
+Creating an account in Digipost and receiving and archiving letters and
+receipts are all free. The User has a specific amount of free storage space
+and the option to send a specific number of letters free of charge each month.
+Information on the available storage space and number of letters can be found
+at www.digipost.no.
+
+If the User makes use of payable services in Digipost, payment must be made
+using a debit card or credit card, including MasterCard and Visa, through a
+secure payment service from a trusted third party. The user must enter the
+required card information. This information will be stored by a trusted third
+party in order to facilitate future payments.
+
+By entering valid card information, the User accepts that Digipost can debit
+the debit card/account for all purchases in Digipost, and that the amount for
+subscription services can be deducted automatically when due. The User is
+obliged to ensure that the card entered is valid, that they can use it and
+that it has sufficient coverage for future due payments. The amount charged to
+the account will follow the price list in force at any time, with the addition
+of statutory VAT at the time of payment.
+
+## **3** SERVICE LEVEL
+
+Digipost aims to be available to customers and users 24 hours a day, 7 days a
+week. Norway Post may suspend service in the event of a technical fault,
+software upgrade, system maintenance, changes, power failure or similar
+conditions.
+
+If Norway Post is aware that the service will be suspended, Norway Post shall
+notify the User of this within a reasonable period of time before the service
+is cancelled. Norway Post shall notify the User as soon as possible if the
+suspension of the service is not known in advance.
+
+Norway Post is not obliged to notify the User if suspension of the service is
+assumed not to be of significance to the User.
+
+Notification may be in the form of a message sent to the email address
+provided by the User when registering, to the User’s Digipost mailbox and/or
+at www.digipost.no.
+
+Messages through Digipost will be processed on an ongoing basis and the
+messages will be available to the recipient in accordance with the agreement
+with the sender, normally immediately after sending. However, the send time
+may vary, and the send time may increase when there are many simultaneous
+tasks or large tasks in progress.
+
+## **4** USE OF DIGIPOST
+
+### **4.1** General
+
+The User shall only use Digipost as described in these Terms.
+
+The User can log on to Digipost with ID-porten or other similar security
+instrument approved by Norway Post. The password/code is the User’s signature
+when using Digipost. It will be assumed that it is the User who has made use
+of the service in question on Digipost where the correct login is used. The
+same applies if the User has granted others access through the sharing
+functionality in Digipost.
+
+The security solutions are protected by a password/code which is personal. The
+User is solely responsible for its use. It is therefore extremely important
+that a unique password/code is used which are never given to others or written
+down so that unauthorised persons can pretend to be the User with regard to
+Digipost. The password should be changed in accordance with the specifications
+stated as requirements for the security solution at any given time.
+
+The User is solely responsible for losses resulting from the User giving their
+Digipost information to others or that others have such access as a result of
+circumstances on the User's side.
+
+The User undertakes not to hack illegally into data resources to which
+Digipost grants access or otherwise use unlawful means to acquire data or
+information. The same applies to other attempts to breach security or
+unnecessarily disrupt other parties’ use of Digipost. If the User
+inadvertently gains access to other users’ or customers’ data in Digipost, the
+User shall notify Norway Post in writing of the matter immediately and delete
+any data received by the User.
+
+Norway Post does not monitor the content of messages that are sent to,
+received, signed or archived in the Digipost mailbox, and is thus not
+responsible for the content and form of the messages, as well as the content
+of any links. Nor is Norway Post responsible for errors, shortcomings and/or
+undesirable properties of relevant data, file attachments, links, etc.
+
+All necessary personal data that Norway Post has about the User must be
+updated at all times. The User shall personally provide notification of any
+changes to email addresses, and other conditions of significance to the use of
+Digipost by logging in to www.digipost.no and changing this under personal
+settings.
+
+If the User discovers errors, shortcomings, irregularities or other conditions
+that may be significant for Norway Post as a supplier of Digipost, the User
+shall notify Norway Post about this.
+
+### **4.2** Sending messages
+
+The User undertakes to identify or label messages in the manner required by
+Norway Post at any time.
+
+The User must have registered as a business customer in order to use Digipost
+for the sending of invoices and for marketing enquiries in business
+activities, etc.
+
+### **4.3** Receipt and archiving of messages
+
+The User grants permission for all potential senders, including public
+authorities, companies, organisations and private individuals, to use Digipost
+for communication with the User. When the User has been registered, all
+senders may send the User digital mail, including invoices, health
+documentation, insurance agreements, notifications and letters from public
+entities, regardless of prior consents to electronic communication. Senders
+may choose only to send the User letters in Digipost. This means that the User
+will not receive the letters in their physical mailbox/postbox. The User
+understands and accepts that the sender’s use of Digipost replaces equivalent
+communication via regular post to the User’s physical mailbox/postbox.
+
+The User will receive notification (by email/SMS/push, depending on what is
+offered by Digipost), about messages received at the Customer’s Digipost
+mailbox. The User can change the settings for receiving such notifications in
+their personal profile. In any event, the User is personally responsible for
+maintaining an ongoing overview of new messages received in Digipost.
+
+The User has the option of archiving messages in Digipost. Messages that the
+User deletes in Digipost will be unavailable to the User immediately after the
+User has confirmed that the message is to be deleted.
+
+Senders of messages in Digipost can request confirmation that the message has
+been opened by the User. Such messages will be marked with information for the
+User to indicate that the sender will be notified when the message is opened.
+
+All messages received in Digipost are stored on secure servers.
+
+Digipost gives the User the opportunity to create a personal, secure digital
+archive where the User can transfer and store digital files to secure servers,
+and which gives the User access to the files via the Internet. Digipost offers
+a given amount of storage space free of charge. The amount of free storage
+space available at any time is specified at digipost.no.
+
+## **5** NORWAY POST’S OBLIGATIONS AND RIGHTS
+
+Norway Post is responsible for carrying out the tasks that the User initiates
+pursuant to these Terms.
+
+Norway Post is not liable for errors, shortcomings or disruptions related to
+equipment, software, access to or transmission via the Internet or the User’s
+selected authentication solution (BankID issued by any bank in Norway, or any
+other corresponding security instrument approved by Norway Post).
+
+Norway Post does not monitor the content of messages that are sent to,
+received or archived in the Digipost mailbox, and is thus not responsible for
+the content and form of the messages, as well as the content of any links.
+
+If Norway Post becomes aware that messages in Digipost have been sent
+incorrectly or are contrary to legislation, regulations or official decisions,
+or otherwise involve abuse of Digipost in the opinion of Norway Post, Norway
+Post may withdraw these. The above also applies to messages that have already
+been delivered to the User’s Digipost mailbox. Norway Post will inform the
+User if such withdrawal takes place.
+
+Norway Post has the opportunity to send messages to the User regarding new
+opportunities, operational information and other information related to
+Digipost.
+
+## **6** CHANGES
+
+Norway Post may change the Terms, including prices, with one month’s written
+notice to the User. Notification will be sent to the email address provided by
+the User, or to the User’s Digipost mailbox. The same applies if Norway Post
+makes significant restrictions in Digipost’s area of use. Changes may
+nevertheless be made without prior notice if the change, in the opinion of
+Norway Post, is of benefit to the User, or is of minor significance. Norway
+Post shall nevertheless inform the User of the change by sending a message to
+the User’s registered email address, Digipost mailbox and/or the next time the
+User logs in to Digipost unless the change is clearly insignificant.
+
+If the area of use in Digipost is expanded to include new functions, the User
+may have to confirm these separately. Information about new functions will be
+updated on an ongoing basis at www.digipost.no and/or by sending a message to
+the User’s Digipost mailbox.
+
+## **7** DUTY OF SECRECY
+
+Norway Post and anyone who carries out work or services for Norway Post have a
+duty of secrecy concerning all information that they may become aware of about
+the User’s use of Digipost.
+
+Norway Post is obliged to take whatever precautions are necessary to ensure
+that material or information are not used for purposes other than the
+implementation of the agreement covered by these Terms or made known to others
+in violation of this paragraph. Employees or others who resign from their
+positions with Norway Post remain bound by this confidentiality clause on
+matters mentioned above also following their resignation.
+
+The duty of confidentiality also applies after the contractual relationship
+under these Terms has ceased.
+
+The duty of confidentiality does not apply when there is an obligation to
+provide material or information pursuant to law, regulation or official
+decision.
+
+## **8** PROCESSING OF PERSONAL DATA
+
+Norway Post will process personal data as a result of the User using Digipost
+and will comply with the provisions of the applicable personal data
+regulations in all processing of personal data. The Data Owner is Norway Post
+AS, PO Box 1500 Sentrum, 0001 Oslo.
+
+The processing of personal data and the User’s rights are described in more
+detail in the privacy policy.
+
+## **9** DIGIPOST ERRORS OR DEFECTS
+
+### **9.1** Complaints
+
+The User must inform Norway Post of errors or shortcomings in Digipost that
+result in the User not being provided with the services to which the User is
+entitled under these Terms. Notification must be provided within a reasonable
+time and no later than 10 days after the User discovered or ought to have
+discovered the defect or shortcoming.
+
+### **9.2** Corrective measures
+
+Norway Post must implement measures to correct the error or shortcoming as
+soon as possible after having been made aware of such an error or shortcoming
+in Digipost.
+
+### **9.3** Price reduction
+
+If there are errors or shortcomings in Digipost in the User’s use for which
+Norway Post is responsible under these Terms and which result in the User not
+being provided with the services to which the User is entitled, the User may
+claim a price reduction insofar as the User has paid for the use of
+Digipost/services in Digipost. In such cases, the User will normally be
+credited a proportional price reduction for the service in question. Where the
+relevant service has been absent in its entirety and this is due to
+circumstances for which Digipost is responsible, the User will be entitled to
+a refund of the price paid for the service. If the User has been prevented
+from sending out messages, the User will not be entitled to a price reduction
+for these messages, but may be entitled to compensation if the conditions for
+this are met.
+
+### **9.4** Compensation Limitation of liability
+
+Norway Post is liable for direct losses incurred by the User in the event of
+errors or shortcomings in Digipost for which Norway Post is responsible under
+these Terms, and which result in the User not being provided with the services
+to which the User is entitled under these Terms, if this is due to gross
+negligence on the part of Norway Post. Direct loss is understood to mean
+necessary and documented additional costs incurred by the User as a result of
+the error or shortcoming.
+
+In no way is Norway Post liable for consequential losses or indirect losses as
+a result of such errors or shortcomings, unless the loss is caused by wilful
+intent on the part of Norway Post. Indirect losses include, but are not
+limited to, loss as a result of reduced or lost production or turnover
+(operational interruption), loss as a result of the service not being usable
+as intended (loss of use), loss of profits as a result of a contract with a
+third party being lost or not being fulfilled, or loss as a result of
+corrupted or impaired data, or other unforeseen damage due to a breach or
+error in the service.
+
+However, under no circumstances is Norway Post responsible for messages
+failing to arrive on time. The services are based on the User keeping their
+own login details secret. Norway Post is not responsible for the data that the
+User sends or receives when using Digipost. Norway Post is not liable for any
+loss, damage or otherwise in connection with the destruction of the User’s
+data, interruptions, undelivered data, incorrectly delivered data, refusal,
+removal or deletion of messages in accordance with clause 5 or similar. Nor
+can Norway Post be held liable if third parties or users of Digipost,
+deliberately or unconsciously, gain access to the User’s data, hinder or
+impede the User’s use of Digipost.
+
+Under all circumstances Norway Post’s total liability to the User is limited
+to an amount equivalent to the price of the service provided, but a maximum of
+NOK 30,000 for each claim/each event of liability. This does not apply if the
+User’s losses are due to wilful intent on the part of Norway Post. If the
+User’s direct losses are due to contract personnel that Norway Post has
+engaged to perform its services to the User, Norway Post will be liable only
+if these contract personnel would also be liable in accordance with the above
+in the same way as Norway Post would have been.
+
+Digipost allows the User to transfer data from invoices received in Digipost
+to the User’s online bank for processing there. The User is personally
+responsible for the processing of invoices in the online bank and for ensuring
+that the correct account is charged at the correct time.
+
+### **9.5** Termination
+
+If there is material breach by Norway Post, the User can terminate the
+contractual relationship that the User has with Norway Post under these Terms
+with immediate effect by providing written notice to Norway Post. Point 15,
+second paragraph applies for the implementation of such termination to the
+extent appropriate.
+
+## **10** BREACH OF CONTRACT BY THE USER
+
+### **10.1** Payment default by the User
+
+In the event of a payment default, Norway Post can claim interest on overdue
+payments in accordance with the Act relating to Interest on Overdue Payments.
+Norway Post can also impose statutory fees when collecting outstanding
+payments from the User at any time. Any outstanding claim shall be deemed to
+be overdue in the event of default of payment.
+
+### **10.2** Termination and closure
+
+Norway Post can immediately terminate the contractual relationship with the
+User in accordance with these Terms in the event of a material breach on the
+part of the User. Upon termination, the User shall be notified that access to
+send and receive messages has been deactivated and that access to stored data
+will cease after 3 months. Material breaches include the use of Digipost by
+the User for the sending of invoices or marketing enquiries in business
+activities, payment defaults, the User violating legislation, regulations or
+official decisions, or otherwise abusing Digipost or information or data that
+is part of Digipost. Reference is also made to Norway Post’s general payment
+terms and conditions, which apply insofar as they are applicable.
+
+Norway Post is entitled to temporarily close access to Digipost (suspension)
+until surveys or clarifications have been completed regarding the User’s use
+of Digipost. As far as possible, Norway Post shall notify the User in writing
+by email and/or message to the User’s Digipost mailbox before temporarily
+closing access to Digipost.
+
+Point 15, second paragraph applies for the implementation of such termination
+to the extent appropriate.
+
+## **11** INDEMNIFICATION
+
+The User shall indemnify Norway Post insofar as Norway Post receives claims
+from or is subject to liability in respect of a third party, and the claim or
+liability is based on the User’s infringement or participation in infringement
+of other parties’ rights protected by law (including, but not limited to
+copyright or adjoining rights, patents, trademarks, designs, know-how or trade
+secrets), or breach of or participation in breach of any law, regulation or
+official decision and/or these Terms when using Digipost. In such cases, the
+User shall have the right to intervene in the claim, or shall be given the
+opportunity in collaboration with Norway Post to safeguard its interests as if
+the claim had been made against the User itself. If such a claim is made
+against Norway Post, the User shall cover, apart from direct financial losses,
+expenses for assistance in handling the claim in a responsible manner and
+other expenses that are reasonably linked with third-party claims. The User
+shall immediately notify Norway Post in writing if the User becomes aware that
+claims will be made against Norway Post in connection with the User’s use of
+Digipost.
+
+## **12** GROUNDS FOR EXEMPTION (FORCE MAJEURE)
+
+Norway Post is not liable for losses arising from statutory intervention or
+administrative acts, actual or threat of war, rebellion, civil unrest,
+vandalism, sabotage, terrorism, strikes, lockouts, boycotts and blockades,
+regardless of whether it is Norway Post itself or the Norway Post organization
+the conflict is aimed at, or implemented by, and regardless of the grounds for
+the conflict, including also when the conflict only affects parts of Norway
+Post's functions, as well as interruptions to IT operations (including the
+failure of deliveries from external suppliers) due to the above.
+
+## **13** TRANSFER OF RIGHTS AND OBLIGATIONS, ETC.
+
+Norway Post can freely assign its rights and obligations under the agreement
+according to these Terms between companies within the Norway Post group. The
+right to remuneration may be freely transferred outside the Norway Post Group.
+
+The User cannot transfer the right to use Digipost as this right is linked to
+the party in question personally. However, the User has the opportunity to
+share access to the User’s Digipost mailbox through the sharing functionality
+in the solution.
+
+The services in Digipost may not be sold, rented out or otherwise made
+available to third parties, including by the User performing services for
+third parties, either for payment or free of charge.
+
+## **14** NOTICE
+
+Unless otherwise expressly provided by these Terms, notice in connection with
+the contractual relationship under these Terms must be provided in writing and
+sent to the following address:
+
+To Norway Post:
+
+email: [kundeservice@digipost.no](mailto:kundeservice@digipost.no) eller
+
+postal address:<br />
+Posten Norge AS<br />
+Att: Digipost<br />
+Postboks 1500 Sentrum<br />
+0001 Oslo
+
+To the User: The User’s Digipost mailbox, the email address that the User
+provided during registration or the postal address that the Customer has
+registered with Norway Post.
+
+## **15** REGULAR TERMINATION
+
+The parties have a mutual right to terminate the agreement under these Terms
+by providing two weeks’ written notice, without further justification,
+provided that all outstanding issues have been settled and that the parties do
+not have claims against each other.
+
+Upon termination of the Agreement, the User’s right to send and receive
+messages will be deactivated at the termination date. Messages that were sent
+by the sender with postponed delivery before the termination date will still
+be delivered to the User in Digipost up to two weeks after the termination
+date. The User will have access to stored data for three months after the
+termination date. During this period, the User will also be able to transfer
+messages from the public sector to another digital mailbox with which the
+public sector has an agreement, via separate functionality for this in
+Digipost. The stored data is then deleted. The User is personally responsible
+for making copies of all data that the User wishes to retain after the
+termination date. Norway Post reserves the right to retain the data necessary
+for following up the customer relationship.
+
+If the User’s Digipost account has been inactive for more than 14 months,
+Norway Post can deactivate the option to send and receive messages if the
+account is still inactive 14 days after Norway Post has sent notification of
+deactivation.
+
+If the User dies, the User’s Digipost account and stored data will be deleted
+12 months after Posten was notified of the death. The person(s) with legal
+power to commit the User must contact Digipost to access the User’s Digipost
+account before deletion. Norway Post reserves the right to retain the data
+necessary for following up the customer relationship.
+
+## **16** JURISDICTION AND VENUE
+
+The contract is subject to and shall be interpreted according to Norwegian
+law. Attempts shall be made to settle disputes between Norway Post and the
+User amicably. If this is not possible, either party may bring the dispute
+before the ordinary courts in accordance with the rules of the Disputes Act
+regarding venue.
+
+Last updated August 18, 2022

--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -48,7 +48,7 @@ Meddelelser gjennom Digipost vil behandles fortløpende og meddelelsene vil vær
 
 Brukeren skal kun benytte Digipost som beskrevet i disse Vilkårene.
 
-Brukeren kan logge seg på Digipost med BankID utstedt av hvilken som helst bank i Norge, eller annet tilsvarende sikkerhetsinstrument godkjent av Posten. Passord/kode generert fra slikt sikkerhetsinstrument er Brukerens signatur ved bruk av Digipost. Det vil bli lagt til grunn at det er Brukeren som har benyttet seg av den enkelte tjeneste på Digipost der hvor korrekt passord er benyttet. Det samme gjelder dersom Brukeren har gitt andre tilgang gjennom delingsfunksjonaliteten i Digipost.
+Brukeren kan logge seg på Digipost med ID-porten eller annet tilsvarende sikkerhetsinstrument godkjent av Posten. Passord/kode generert fra slikt sikkerhetsinstrument er Brukerens signatur ved bruk av Digipost. Det vil bli lagt til grunn at det er Brukeren som har benyttet seg av den enkelte tjeneste på Digipost der hvor korrekt pålogging er benyttet. Det samme gjelder dersom Brukeren har gitt andre tilgang gjennom delingsfunksjonaliteten i Digipost.
 
 Sikkerhetsløsningene er beskyttet av et passord/kode og er personlig. Brukeren er selv ansvarlig for bruken. Det er derfor svært viktig at det brukes et unikt passord/kode og at det aldri oppgis eller skrives ned slik at uvedkommende kan utgi seg for å være Brukeren overfor Digipost. Passordet skal endres i samsvar med det som til enhver tid angis som krav til sikkerhetsløsningen.
 
@@ -82,7 +82,7 @@ Avsendere av Meddelelser i Digipost kan be om bekreftelse på at Meddelelsen er 
 
 Posten er ansvarlig for utføring av de oppdrag som Brukeren iverksetter i henhold til disse Vilkårene.
 
-Postens ansvar omfatter ikke feil, mangler eller driftsforstyrrelser knyttet til utstyr, programvare, tilgang til eller overføring over Internett eller Brukerens valgte autentiseringsløsning (BankID utstedt av hvilken som helst bank i Norge, eller annet tilsvarende sikkerhetsinstrument godkjent av Posten).
+Postens ansvar omfatter ikke feil, mangler eller driftsforstyrrelser knyttet til utstyr, programvare, tilgang til eller overføring over Internett eller Brukerens valgte autentiseringsløsning (ID-porten eller annet tilsvarende sikkerhetsinstrument godkjent av Posten).
 
 Posten overvåker ikke innholdet i Meddelelser som sendes til, mottas eller arkiveres i Digipost-postkassen, og er således ikke ansvarlig for Meddelelsenes innhold og form, samt innhold i eventuelle lenker.
 

--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -196,7 +196,7 @@ Ved opphør av avtalen ved oppsigelse vil Brukerens adgang til å sende og motta
 
 Dersom Brukerens Digipost-konto har vært inaktiv i mer enn 14 måneder, kan Posten deaktivere muligheten til å sende og motta Meddelelser hvis kontoen fortsatt er inaktiv 14 dager etter at Posten har sendt varsel om deaktivering.
 
-Dersom Brukeren dør, vil Brukerens Digipost-konto og lagrede data slettes tre måneder etter at Posten fikk beskjed om dødsfallet. De(n) som kan forplikte Brukeren må kontakte Digipost for å få tilgang til Brukerens Digipost-konto innen sletting. Posten forbeholder seg retten til å beholde data som er nødvendig for oppfølging av kundeforholdet.
+Dersom Brukeren dør, vil Brukerens Digipost-konto og lagrede data slettes 12 måneder etter at Posten fikk beskjed om dødsfallet. De(n) som kan forplikte Brukeren må kontakte Digipost for å få tilgang til Brukerens Digipost-konto innen sletting. Posten forbeholder seg retten til å beholde data som er nødvendig for oppfølging av kundeforholdet.
 
 ## **16** PRODUKT- OG BETALINGSVILKÅR FOR SIKKER LAGRING
 

--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -78,6 +78,11 @@ Brukeren har mulighet til å arkivere Meddelelser i Digipost. Meddelelser som Br
 
 Avsendere av Meddelelser i Digipost kan be om bekreftelse på at Meddelelsen er åpnet av Brukeren. Slike Meddelelser vil være merket med informasjon til Bruker om at avsender blir varslet ved åpning av Meddelelsen.
 
+Alle Meddelelser mottatt i Digipost blir lagret på sikre servere.
+
+Gjennom Digipost får Brukeren mulighet til å lage et personlig, sikkert digitalt arkiv hvor Brukeren kan overføre og lagre digitale filer til sikre servere, og som gir Brukeren tilgang til filene via Internett. Digipost tilbyr
+en gitt mengde lagringsplass gratis. Den til enhver tid tilgjengelige mengden gratis lagringsplass er spesifisert på digipost.no.
+
 ## **5** POSTENS PLIKTER OG RETTIGHETER
 
 Posten er ansvarlig for utføring av de oppdrag som Brukeren iverksetter i henhold til disse Vilkårene.
@@ -202,4 +207,4 @@ Dersom Brukeren dør, vil Brukerens Digipost-konto og lagrede data slettes 12 m�
 
 Kontrakten er underlagt og skal tolkes i samsvar med norsk rett. Tvister mellom Posten og Brukeren skal søkes løst i minnelighet. Dersom det ikke lar seg gjøre, kan hver av partene bringe tvisten inn for de ordinære domstoler i samsvar med tvistelovens regler vedrørende verneting.
 
-Sist oppdatert 14. september 2021
+Sist oppdatert 18. august 2022

--- a/digipost-vilkaar-privat.md
+++ b/digipost-vilkaar-privat.md
@@ -198,25 +198,7 @@ Dersom Brukerens Digipost-konto har vært inaktiv i mer enn 14 måneder, kan Pos
 
 Dersom Brukeren dør, vil Brukerens Digipost-konto og lagrede data slettes 12 måneder etter at Posten fikk beskjed om dødsfallet. De(n) som kan forplikte Brukeren må kontakte Digipost for å få tilgang til Brukerens Digipost-konto innen sletting. Posten forbeholder seg retten til å beholde data som er nødvendig for oppfølging av kundeforholdet.
 
-## **16** PRODUKT- OG BETALINGSVILKÅR FOR SIKKER LAGRING
-
-Alle Meddelelser mottatt i Digipost blir lagret på sikre servere.
-
-Gjennom Digipost får Brukeren mulighet til å lage et personlig, sikkert digitalt arkiv hvor Brukeren kan overføre og lagre digitale filer til sikre servere, og som gir Brukeren tilgang til filene via Internett. Digipost tilbyr en gitt mengde lagringsplass gratis. Den til enhver tid tilgjengelige mengden gratis lagringsplass er spesifisert på digipost.no.
-
-Brukere som ønsker mer lagringsplass enn det Digipost tilbyr gratis, kan betale for mer plass. Digipost tilbyr flere nivåer med ulik lagringskapasitet. Brukeren kan når som helst oppgradere fra Digipost sin gratistjeneste til et av Digipost sine produkter for økt lagringskapasitet. Den økte lagringskapasiteten vil umiddelbart bli tilgjengelig etter utført betaling.
-
-Digipost sin lagringstjeneste er et løpende abonnement med automatisk fornyelse. Brukeren bestiller og betaler forskuddsbasert for abonnementet frem til abonnementsperioden for det aktuelle abonnement utløper. Abonnementet fornyes deretter automatisk, og Brukerens bankkort/konto vil bli belastet på nytt ved periodens slutt inntil brukeren selv velger å stoppe eller endre abonnementet. Digipost sine abonnement og priser finnes på www.digipost.no.
-
-Kjøp av lagring gir Brukeren mulighet for å laste opp og lagre dokumenter opp til produktets øvre lagringsgrense. Beløpet som belastes vil ta utgangspunkt i valgt produkt og er uavhengig av om faktisk benyttet lagringsplass er lavere enn den øvre lagringsgrensen og uavhengig av om et rimeligere abonnement kunne vært valgt.
-
-Brukeren har mulighet til å administrere sitt abonnement under personlige innstillinger på digipost.no. Her vil Brukeren også få oversikt over aktivt abonnement, tidligere abonnementer og tidligere betalinger/trekk.
-
-Brukeren kan til enhver tid oppgradere eller nedgradere sitt abonnement. For å kunne nedgradere gjeldende abonnement må Brukeren først sørge for at benyttet lagringsplass er under maksimal lagringsgrense. Endringene vil tre i kraft umiddelbart. Digipost refunderer ikke penger for abonnement som er endret før abonnementsperioden er avsluttet.
-
-Ved mislighold vil Digipost kunne sperre utvalgt funksjonalitet og tilgang for Brukeren. Dersom betaling av abonnement ikke kan gjennomføres, for eksempel ved at registrert kort har gått ut eller at det ikke er dekning på konto, vil Digipost stenge for at Brukeren kan laste opp nye dokumenter og sende brev gjennom Digipost. Digipost vil også kunne sperre for Brukerens tilgang dersom tjenesten misbrukes eller benyttes på en måte som strider mot norsk lov. For øvrig vises det til punkt 10.
-
-## **17** JURISDIKSJON OG VERNETING
+## **16** JURISDIKSJON OG VERNETING
 
 Kontrakten er underlagt og skal tolkes i samsvar med norsk rett. Tvister mellom Posten og Brukeren skal søkes løst i minnelighet. Dersom det ikke lar seg gjøre, kan hver av partene bringe tvisten inn for de ordinære domstoler i samsvar med tvistelovens regler vedrørende verneting.
 


### PR DESCRIPTION
- Etter dødsfall stenges konto etter 9 måneder i stedet for 6. Etter 3 måneder til blir den slettet, men hele prosessen tar altså nå 9+3=12 måneder totalt.
- Vilkår for privatpersoner + personvernerklæring finnes nå på engelsk. Vilkår for bedrifter finnes fortsatt bare på norsk.
- Se ellers commitmeldingene for å se andre mindre endringer som er gjort.

Tilsvarende PR i postit der dokumentene ligger: https://github.com/digipost/digipost-postit/pull/424